### PR TITLE
環境変数でトークンを設定できるよう修正

### DIFF
--- a/js/tootbox.js
+++ b/js/tootbox.js
@@ -1,5 +1,8 @@
-
-const token = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+let token = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+const envToken = process.env.MASTODON_TOKEN
+if (envToken && envToken.length > 0) {
+  token = envToken
+}
 
 function toot_send() {
   const url = 'https://mstdn-workers.com/api/v1/statuses'


### PR DESCRIPTION
自分のトークンでテストする際に間違えてコミットしてしまいそうなので機能追加

* windowsは setenv MASTODON_TOKEN=xxxxx
* linuxは export MASTODON_TOKEN=xxxxx

で設定可能